### PR TITLE
fix shtab bug (copied from pm64 repo)

### DIFF
--- a/bfd/elf32-mips.c
+++ b/bfd/elf32-mips.c
@@ -1472,7 +1472,10 @@ mips_elf_sym_is_global (abfd, sym)
      bfd *abfd;
      asymbol *sym;
 {
-  return (sym->flags & BSF_SECTION_SYM) == 0 ? true : false;
+    //return (sym->flags & BSF_SECTION_SYM) == 0 ? true : false;
+  return ((sym->flags & (BSF_GLOBAL | BSF_WEAK)) != 0
+	    || bfd_is_und_section (sym->section)
+	    || bfd_is_com_section (sym->section));
 }
 
 /* Set the right machine number for a MIPS ELF file.  This is used for

--- a/libiberty/Makefile.in
+++ b/libiberty/Makefile.in
@@ -217,19 +217,12 @@ config.h: $(CONFIG_H)
 lconfig.h: needed2.awk errors
 	echo "/* !Automatically generated from $(srcdir)/functions.def"\
 	  "- DO NOT EDIT! */" >lconfig.h
-	awk -f needed2.awk <errors >>lconfig.h
 
 # Generate an awk script that looks for variables in functions.def
 
 needed2.awk: $(srcdir)/functions.def Makefile
 	echo "# !Automatically generated from $(srcdir)/functions.def"\
 	  "- DO NOT EDIT!" >needed2.awk
-	grep '^DEFVAR(' < $(srcdir)/functions.def \
-	 | sed -e '/DEFVAR/s|DEFVAR.\([^,]*\).*|/\1/ { printf "#ifndef NEED_\1\\n#define NEED_\1\\n#endif\\n" }|' \
-	 >>needed2.awk
-	grep '^DEFFUNC(' < $(srcdir)/functions.def \
-	 | sed -e '/DEFFUNC/s|DEFFUNC.\([^,]*\).*|/\1/ { printf "#ifndef NEED_\1\\n#define NEED_\1\\n#endif\\n" }|' \
-	 >>needed2.awk
 
 dummy.o: $(srcdir)/dummy.c $(srcdir)/functions.def
 	$(CC) -c $(CFLAGS) -I. -I$(INCDIR) $(HDEFINES) $(srcdir)/dummy.c 2>/dev/null


### PR DESCRIPTION
fixes bug where this would occur when doing _make_
mips-linux-gnu-ld: build/src/thread3_main.o: .symtab local symbol at index 6 (>= sh_info of 6)